### PR TITLE
Add a seccomp profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     container_name: "libreddit"
     ports:
       - 8080:8080
+    cap_drop:
+      - ALL
     security_opt:
       - seccomp="seccomp-libreddit.json"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     container_name: "libreddit"
     ports:
       - 8080:8080
+    security_opt:
+      - seccomp="seccomp-libreddit.json"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "--tries=1", "http://localhost:8080/settings"]
       interval: 5m

--- a/seccomp-libreddit.json
+++ b/seccomp-libreddit.json
@@ -1,0 +1,125 @@
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "archMap": [
+    {
+      "architecture": "SCMP_ARCH_X86_64",
+      "subArchitectures": [
+        "SCMP_ARCH_X86",
+        "SCMP_ARCH_X32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_AARCH64",
+      "subArchitectures": [
+        "SCMP_ARCH_ARM"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_S390X",
+      "subArchitectures": [
+        "SCMP_ARCH_S390"
+      ]
+    }
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "accept4",
+        "arch_prctl",
+        "bind",
+        "brk",
+        "clock_gettime",
+        "clone",
+        "close",
+        "connect",
+        "epoll_create1",
+        "epoll_ctl",
+        "epoll_pwait",
+        "eventfd2",
+        "execve",
+        "exit",
+        "exit_group",
+        "fcntl",
+        "flock",
+        "fork",
+        "fstat",
+        "futex",
+        "getcwd",
+        "getpeername",
+        "getpid",
+        "getrandom",
+        "getsockname",
+        "getsockopt",
+        "getgid",
+        "getppid",
+        "gettid",
+        "getuid",
+        "ioctl",
+        "listen",
+        "lseek",
+        "madvise",
+        "mmap",
+        "mprotect",
+        "mremap",
+        "munmap",
+        "newfstatat",
+        "open",
+        "openat",
+        "prctl",
+        "poll",
+        "read",
+        "recvfrom",
+        "rt_sigaction",
+        "rt_sigprocmask",
+        "rt_sigreturn",
+        "sched_getaffinity",
+        "sched_yield",
+        "sendto",
+        "setitimer",
+        "setsockopt",
+        "set_tid_address",
+        "shutdown",
+        "sigaltstack",
+        "socket",
+        "socketpair",
+        "stat",
+        "wait4",
+        "write",
+        "writev"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    }
+  ]
+}


### PR DESCRIPTION
I've been running libreddit without any Linux capabilities and with this seccomp profile for a while without issue, and figured it was worth sharing upstream to see if there's any interest.

Note that `wget` does use `setgid`/`setuid`. I haven't dug into what it's trying to accomplish by dropping (or raising?) privileges, but the healthcheck does run just fine as the main container user.

Important: I do not use `docker-compose`, so I haven't validated the syntax of these changes. They _look_ correct as per the [reference documentation](https://docs.docker.com/compose/compose-file/compose-file-v3/), but should still be explicitly validated.