### PR TITLE
build: enable LTO and strip the binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ tokio = { version = "1.21.2", features = ["full"] }
 time = "0.3.16"
 url = "2.3.1"
 rust-embed = { version = "6.4.2", features = ["include-exclude"] }
+
+[profile.release]
+codegen-units = 1
+lto = true
+strip = true


### PR DESCRIPTION
This PR enable the link time optimization and strip the binary to reduce his size in release mode.

With this PR, the build time of `cargo build --release --target x86_64-unknown-linux-musl` increased from 3m00s to 3m15s but the binary size dropped from 15M to 6.3M.

I do not have any metrics to see how effective is the LTO.
