### PR TITLE
Speed up heroku deployment

### DIFF
--- a/Dockerfile.fromimage
+++ b/Dockerfile.fromimage
@@ -1,0 +1,4 @@
+FROM spikecodes/libreddit:latest
+# Exposing port 8080 only for local testing
+EXPOSE 8080
+CMD ["libreddit"]

--- a/app.json
+++ b/app.json
@@ -1,44 +1,50 @@
 {
   "name": "Libreddit",
   "description": "Private front-end for Reddit",
-  "buildpacks": [
-    {
-      "url": "https://github.com/emk/heroku-buildpack-rust"
-    },
-    {
-      "url": "emk/rust"
-    }
-  ],
   "stack": "container",
   "env": {
     "LIBREDDIT_DEFAULT_THEME": {
+      "value": "system",
       "required": false
     },
     "LIBREDDIT_DEFAULT_FRONT_PAGE": {
+      "value": "default",
       "required": false
     },
     "LIBREDDIT_DEFAULT_LAYOUT": {
+      "value": "card",
       "required": false
     },
     "LIBREDDIT_DEFAULT_WIDE": {
+      "value": "off",
       "required": false
     },
     "LIBREDDIT_DEFAULT_COMMENT_SORT": {
+      "value": "confidence",
       "required": false
     },
     "LIBREDDIT_DEFAULT_POST_SORT": {
+      "value": "hot",
       "required": false
     },
     "LIBREDDIT_DEFAULT_SHOW_NSFW": {
+      "value": "off",
       "required": false
     },
     "LIBREDDIT_DEFAULT_BLUR_NSFW": {
+      "value": "off",
       "required": false
     },
-    "LIBREDDIT_USE_HLS": {
+    "LIBREDDIT_DEFAULT_USE_HLS": {
+      "value": "off",
       "required": false
     },
-    "LIBREDDIT_HIDE_HLS_NOTIFICATION": {
+    "LIBREDDIT_DEFAULT_HIDE_HLS_NOTIFICATION": {
+      "value": "off",
+      "required": false
+    },
+    "LIBREDDIT_DEFAULT_AUTOPLAY_VIDEOS": {
+      "value": "off",
       "required": false
     }
   }

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,3 +1,3 @@
 build:
   docker:
-    web: Dockerfile
+    web: Dockerfile.fromimage


### PR DESCRIPTION
### Changelog
- Use `Dockerfile.fromimage` instead of the default `Dockerfile` to directly deploy the docker image from Dockerhub.
This makes deployment much faster than building it in heroku's containers.
- Add new env vars and fix some errors.
Some env vars in `app.json` missed `_DEFAULT_` and `AUTOPLAY_VIDEOS` env var was missing.
- Also, added default values for env vars.
_Can be removed in case it's deemed useless._