### PR TITLE
Implement 'posts hidden because of NSFW'. (Resolves #159)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -46,11 +46,7 @@ pub async fn canonical_path(path: String) -> Result<Option<String>, String> {
 		res
 			.headers()
 			.get(header::LOCATION)
-			.map(|val| percent_encode(val.as_bytes(), CONTROLS)
-				.to_string()
-				.trim_start_matches(REDDIT_URL_BASE)
-				.to_string()
-			),
+			.map(|val| percent_encode(val.as_bytes(), CONTROLS).to_string().trim_start_matches(REDDIT_URL_BASE).to_string()),
 	)
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -42,6 +42,8 @@ struct SearchTemplate {
 	/// Whether all fetched posts are filtered (to differentiate between no posts fetched in the first place,
 	/// and all fetched posts being filtered).
 	all_posts_filtered: bool,
+	/// Whether all posts were hidden because they are NSFW (and user has disabled show NSFW)
+	all_posts_hidden_nsfw: bool,
 }
 
 // SERVICES
@@ -100,12 +102,13 @@ pub async fn find(req: Request<Body>) -> Result<Response<Body>, String> {
 			url,
 			is_filtered: true,
 			all_posts_filtered: false,
+			all_posts_hidden_nsfw: false,
 		})
 	} else {
 		match Post::fetch(&path, quarantined).await {
 			Ok((mut posts, after)) => {
 				let all_posts_filtered = filter_posts(&mut posts, &filters);
-
+				let all_posts_hidden_nsfw = posts.iter().all(|p| p.flags.nsfw) && setting(&req, "show_nsfw") != "on";
 				template(SearchTemplate {
 					posts,
 					subreddits,
@@ -123,6 +126,7 @@ pub async fn find(req: Request<Body>) -> Result<Response<Body>, String> {
 					url,
 					is_filtered: false,
 					all_posts_filtered,
+					all_posts_hidden_nsfw,
 				})
 			}
 			Err(msg) => {

--- a/templates/search.html
+++ b/templates/search.html
@@ -56,6 +56,11 @@
 		</div>
 		{% endif %}
 		{% endif %}
+
+		{% if all_posts_hidden_nsfw %}
+		<center>All posts are hidden because they are NSFW. Enable "Show NSFW posts" in settings to view.</center>
+		{% endif %}
+
 		{% if all_posts_filtered %}
 			<center>(All content on this page has been filtered)</center>
 		{% else if is_filtered %}

--- a/templates/subreddit.html
+++ b/templates/subreddit.html
@@ -46,6 +46,10 @@
 				</form>
 			{% endif %}
 
+			{% if all_posts_hidden_nsfw %}
+			<center>All posts are hidden because they are NSFW. Enable "Show NSFW posts" in settings to view.</center>
+			{% endif %}
+
 			{% if all_posts_filtered %}
 				 <center>(All content on this page has been filtered)</center>
 			{% else %}

--- a/templates/user.html
+++ b/templates/user.html
@@ -32,6 +32,10 @@
 				</button>
 			</form>
 
+			{% if all_posts_hidden_nsfw %}
+			<center>All posts are hidden because they are NSFW. Enable "Show NSFW posts" in settings to view.</center>
+			{% endif %}
+
 			{% if all_posts_filtered %}
 				 <center>(All content on this page has been filtered)</center>
 			{% else %}


### PR DESCRIPTION
This is a redo of #508. This is the code in ferritreader/ferrit#9, which @sigaloid (also the author of #508) contributed.

This code should go in as-is for now, in order to reduce the likelihood of merge conflicts as we introduce Ferrit features into Libreddit, but there are issues that we should think about addressing in the future:

1. For reasons unknown, for some user profiles, Reddit will respond to a `GET /user/:user_id/.json` with a 200, but JSON payload will contain no user posts or comments, even if the user in question has content that is visible on Reddit. Normally, Libreddit will display a user page with a user information box on the right but with an empty list of comments/submissions. However, with the changes introduced in this PR, Libreddit will claim that all content was filtered because they were NSFW, which is not actually the case.
1. On the other hand, there are users for whom almost all of their content is NSFW. Occasionally, however, they will have posts/submissions that Reddit deems SFW. These SFW posts/comments will show up in a view of a user's profile, but these items will be fewer than the number of items that we expect in the listing, yet Libreddit will not let you know that content was filtered because they were NSFW.
    - To put it concretely: Suppose a user `:user_id` has a total of 90 contributions on Reddit. Reddit has deemed 80 of those NSFW, but their most recent 10 posts or comments are SFW. By default, Reddit will show 25 posts or comments on each batch of a listing of a user's contributions. If you visited `/user/:user_id` on Libreddit, you will see only 10 posts/comments of the 25 expected, along with a "Next" button to navigate to the next page, but there is no indication from Libreddit that content was filtered because it was NSFW.
    
I think we can resolve (2) with a combination of:
* ferritreader/ferrit#25, which will render a landing page for a Reddit user if Reddit deems their entire user profile NSFW
* Changing the behavior of this code to indicate that _some_, but not _all_, content on a _user page_ was filtered because they were NSFW, which also requires recording whether or not we actually filtered a single NSFW post or not.