### PR TITLE
T.: Docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Assign a default value for each setting by passing environment variables to Libr
 | `POST_SORT`             | `["hot", "new", "top", "rising", "controversial"]`                                                  | `hot`         |
 | `COMMENT_SORT`          | `["confidence", "top", "new", "controversial", "old"]`                                              | `confidence`  |
 | `SHOW_NSFW`             | `["on", "off"]`                                                                                     | `off`         |
+| `BLUR_NSFW`             | `["on", "off"]`                                                                                     | `off`         |
 | `USE_HLS`               | `["on", "off"]`                                                                                     | `off`         |
 | `HIDE_HLS_NOTIFICATION` | `["on", "off"]`                                                                                     | `off`         |
 | `AUTOPLAY_VIDEOS`       | `["on", "off"]`                                                                                     | `off`         |


### PR DESCRIPTION
https://github.com/libreddit/libreddit/commit/fade305f9008991bac72ffe9439142453c03c229 added a setting for blurring "NSFW" post previews, n a corresponding environment variable, however said variable wasn't documented in the Readme. This PR fixes that.