### PR TITLE
make the column in posts consistent

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -154,6 +154,7 @@ main {
 }
 
 #column_one {
+	width: 100%;
 	max-width: 750px;
 	border-radius: 5px;
 	overflow: inherit;


### PR DESCRIPTION
The width isn't consistent in every post: likely because some posts have content that doesn't reach the `max-width: 750px`.

Without `width: 100%`:
![image](https://user-images.githubusercontent.com/62589492/202954345-4ca38f0e-85d3-4665-8d67-d880f8787565.png)

With `width: 100%`:
![image](https://user-images.githubusercontent.com/62589492/202954446-ec7f6d1f-86d2-4822-a33b-3e7afe4e4ce0.png)

Reference: https://libreddit.spike.codes/r/bleach/comments/yzb0o7/episode_6_got_me_like/