### PR TITLE
Extract Location URL path correctly in client::request. (fixes #645)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -158,10 +158,10 @@ fn request(method: &'static Method, path: String, redirect: bool, quarantine: bo
 							method,
 							response
 								.headers()
-								.get("Location")
+								.get(header::LOCATION)
 								.map(|val| {
-									let new_url = percent_encode(val.as_bytes(), CONTROLS).to_string();
-									format!("{}{}raw_json=1", new_url, if new_url.contains('?') { "&" } else { "?" })
+									let new_path = percent_encode(val.as_bytes(), CONTROLS).to_string().trim_start_matches(REDDIT_URL_BASE).to_string();
+									format!("{}{}raw_json=1", new_path, if new_path.contains('?') { "&" } else { "?" })
 								})
 								.unwrap_or_default()
 								.to_string(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -160,6 +160,17 @@ fn request(method: &'static Method, path: String, redirect: bool, quarantine: bo
 								.headers()
 								.get(header::LOCATION)
 								.map(|val| {
+									// We need to make adjustments to the URI
+									// we get back from Reddit. Namely, we
+									// must:
+									//
+									//     1. Remove the authority (e.g.
+									//     https://www.reddit.com) that may be
+									//     present, so that we recurse on the
+									//     path (and query parameters) as
+									//     required.
+									//
+									//     2. Percent-encode the path.
 									let new_path = percent_encode(val.as_bytes(), CONTROLS).to_string().trim_start_matches(REDDIT_URL_BASE).to_string();
 									format!("{}{}raw_json=1", new_path, if new_path.contains('?') { "&" } else { "?" })
 								})


### PR DESCRIPTION
`client::request` when executing the recursive cast will now make sure that it passes the path of a URL (and any query parameters) to its recursive call by filtering out the `REDDIT_URL_BASE` that may be present in the URL.

Fix is confirmed:
```
$ curl -sv -o/dev/null http://localhost:8080/r/an3p9anda
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /r/an3p9anda HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.74.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< content-type: text/html
< referrer-policy: no-referrer
< x-content-type-options: nosniff
< x-frame-options: DENY
< content-security-policy: default-src 'none'; font-src 'self'; script-src 'self' blob:; manifest-src 'self'; media-src 'self' data: blob: about:; style-src 'self' 'unsafe-inline'; base-uri 'none'; img-src 'self' data:; form-action 'self'; frame-ancestors 'none'; connect-src 'self'; worker-src blob:;
< strict-transport-security: max-age=604800
< content-length: 5165
< date: Mon, 21 Nov 2022 06:26:31 GMT
< 
{ [5165 bytes data]
* Connection #0 to host localhost left intact
```