### PR TITLE
Fix embeds

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -13,16 +13,25 @@
 	<!-- Meta Tags -->
 	<meta name="author" content="u/{{ post.author.name }}">
 	<meta name="title" content="{{ post.title }} - r/{{ post.community }}">
-	<meta property="og:type" content="website">
-	<meta property="og:url" content="{{ post.permalink }}">
 	<meta property="og:title" content="{{ post.title }} - r/{{ post.community }}">
 	<meta property="og:description" content="View on Libreddit, an alternative private front-end to Reddit.">
-	<meta property="og:image" content="{{ post.thumbnail.url }}">
-	<meta property="twitter:card" content="summary_large_image">
+	<meta property="og:url" content="{{ post.permalink }}">
 	<meta property="twitter:url" content="{{ post.permalink }}">
 	<meta property="twitter:title" content="{{ post.title }} - r/{{ post.community }}">
 	<meta property="twitter:description" content="View on Libreddit, an alternative private front-end to Reddit.">
+	{% if post.post_type == "image" %}
+	<meta property="og:type" content="image">
+	<meta property="og:image" content="{{ post.thumbnail.url }}">
+	<meta property="twitter:card" content="summary_large_image">
 	<meta property="twitter:image" content="{{ post.thumbnail.url }}">
+	{% else if post.post_type == "video" || post.post_type == "gif" %}
+	<meta property="twitter:card" content="video">
+	<meta property="og:type" content="video">
+	<meta property="og:video" content="{{ post.media.url }}">
+	<meta property="og:video:type" content="video/mp4">
+	{% else %}
+	<meta property="og:type" content="website">
+	{% endif %}
 {% endblock %}
 
 {% block subscriptions %}


### PR DESCRIPTION
This PR makes the embeds for Discord and Telegram prettier by displaying the post's video, if there is one, using OpenGraph meta tags, similarly to [Teddit](https://codeberg.org/teddit/teddit).

Before:
![toQBkX](https://user-images.githubusercontent.com/46872282/204129234-626272c1-0e16-4d90-b122-5fe468da6d44.png)

After:
![HaVXRI](https://user-images.githubusercontent.com/46872282/204129277-84b0a8f7-2f3e-497f-a834-0bfabee493de.png)
