### PR TITLE
Link to `libreddit/libreddit` and open in new tab

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -48,7 +48,7 @@
 						<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
 					</svg>
 				</a>
-				<a id="code" href="https://github.com/spikecodes/libreddit">
+				<a id="code" href="https://github.com/libreddit/libreddit" target="_blank" rel="noopener noreferrer">
 					<span>code</span>
 					<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 						<title>code</title>


### PR DESCRIPTION
This sets the target of the "code" link to `_blank`, so that it will
open in a new tab in browsers. Because the GitHub page is a different
context from libreddit, and accessing the repository doesn't imply that
the user is finished browsing libreddit, this seemed reasonable. This
also changes the link from `spikecodes/libreddit` to
`libreddit/libreddit`.

******

I'm breaking my self-imposed rule of "one effective change per commit", but with a 1-line HTML diff
that didn't seem to matter :laughing:
Depending on how you prefer your diffs/history, I'm happy to change the history of this PR.
