### PR TITLE
Create devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+    "name": "Rust",
+    "image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye",
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    },
+    "portsAttributes": {
+        "8080": {
+            "label": "libreddit",
+            "onAutoForward": "notify"
+        }
+    },
+    "postCreateCommand": "cargo build"
+}


### PR DESCRIPTION
This helps contributors work on libreddit in a GitHub Codespace. Some explanation:
- More can be read about the image [here](https://github.com/devcontainers/images/tree/main/src/rust)
- The docker-in-docker feature allows usage of `docker` in the codespace
- When starting the app on port 8080, it will be labeled "libreddit" and the user will see a notification to open the page in a new tab
- Once the codespace is created, `cargo build` is run. This is somewhat inspired by the default Rust build steps of a gitpod instance. It's not that important, IMO, but the initial build can be kind of lengthy, so it can save a bit of time to have the build already running when you start developing.