### PR TITLE
[Awards] Add an option to display awards.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -113,7 +113,7 @@ pub async fn find(req: Request<Body>) -> Result<Response<Body>, String> {
 			no_posts: false,
 		})
 	} else {
-		match Post::fetch(&path, quarantined).await {
+		match Post::fetch(&path, quarantined, &setting(&req, "display_awards")).await {
 			Ok((mut posts, after)) => {
 				let (_, all_posts_filtered) = filter_posts(&mut posts, &filters);
 				let no_posts = posts.is_empty();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -19,7 +19,7 @@ struct SettingsTemplate {
 
 // CONSTANTS
 
-const PREFS: [&str; 11] = [
+const PREFS: [&str; 12] = [
 	"theme",
 	"front_page",
 	"layout",
@@ -31,6 +31,7 @@ const PREFS: [&str; 11] = [
 	"use_hls",
 	"hide_hls_notification",
 	"autoplay_videos",
+	"display_awards",
 ];
 
 // FUNCTIONS

--- a/src/subreddit.rs
+++ b/src/subreddit.rs
@@ -118,7 +118,7 @@ pub async fn community(req: Request<Body>) -> Result<Response<Body>, String> {
 			no_posts: false,
 		})
 	} else {
-		match Post::fetch(&path, quarantined).await {
+		match Post::fetch(&path, quarantined, &setting(&req, "display_awards")).await {
 			Ok((mut posts, after)) => {
 				let (_, all_posts_filtered) = filter_posts(&mut posts, &filters);
 				let no_posts = posts.is_empty();

--- a/src/user.rs
+++ b/src/user.rs
@@ -66,7 +66,7 @@ pub async fn profile(req: Request<Body>) -> Result<Response<Body>, String> {
 		})
 	} else {
 		// Request user posts/comments from Reddit
-		match Post::fetch(&path, false).await {
+		match Post::fetch(&path, false, &setting(&req, "display_awards")).await {
 			Ok((mut posts, after)) => {
 				let (_, all_posts_filtered) = filter_posts(&mut posts, &filters);
 				let no_posts = posts.is_empty();

--- a/templates/comment.html
+++ b/templates/comment.html
@@ -20,14 +20,16 @@
 			{% endif %}
 			<a href="{{ post_link }}{{ id }}/?context=3" class="created" title="{{ created }}">{{ rel_time }}</a>
 			{% if edited.0 != "".to_string() %}<span class="edited" title="{{ edited.1 }}">edited {{ edited.0 }}</span>{% endif %}
-			{% if !awards.is_empty() %}
+			{% match awards %}
+			{% when Some with (values) %}
 			<span class="dot">&bull;</span>
-			{% for award in awards.clone() %}
+			{% for award in values.clone().iter() %}
 			<span class="award" title="{{ award.name }}">
 				<img alt="{{ award.name }}" src="{{ award.icon_url }}" width="16" height="16"/>
 			</span>
 			{% endfor %}
-			{% endif %}
+			{% when None %}
+			{% endmatch %}
 		</summary>
 		{% if is_filtered %}
 		<div class="comment_body_filtered {% if highlighted %}highlighted{% endif %}">(Filtered content)</div>

--- a/templates/duplicates.html
+++ b/templates/duplicates.html
@@ -65,13 +65,15 @@
                             <a class="post_author {{ post.author.distinguished }}" href="/u/{{ post.author.name }}">u/{{ post.author.name }}</a>
                             <span class="dot">&bull;</span>
                             <span class="created" title="{{ post.created }}">{{ post.rel_time }}</span>
-                            {% if !post.awards.is_empty() %}
-                                {% for award in post.awards.clone() %}
+                            {% match post.awards %}
+                            {% when Some with (values) %}
+                            {% for award in values.clone().iter() %}
                                 <span class="award" title="{{ award.name }}">
                                     <img alt="{{ award.name }}" src="{{ award.icon_url }}" width="16" height="16"/>
                                 </span>
-                                {% endfor %}
-                            {% endif %}
+                            {% endfor %}
+                            {% when None %}
+                            {% endmatch %}
                         </p>
                         <h2 class="post_title">
                             {% if post.flair.flair_parts.len() > 0 %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -70,6 +70,11 @@
 					<input type="checkbox" name="autoplay_videos" id="autoplay_videos" {% if prefs.autoplay_videos == "on" %}checked{% endif %}>
 				</div>
 				<div class="prefs-group">
+					<label for="display_awards">Display awards</label>
+					<input type="hidden" value="off" name="display_awards">
+					<input type="checkbox" name="display_awards" id="display_awards" {% if prefs.display_awards == "on" %}checked{% endif %}>
+				</div>
+				<div class="prefs-group">
 					<label for="use_hls">Use HLS for videos</label>
 					<details id="feeds">
 						<summary>Why?</summary>

--- a/templates/utils.html
+++ b/templates/utils.html
@@ -73,17 +73,19 @@
 		{% endif %}
 		<span class="dot">&bull;</span>
 		<span class="created" title="{{ post.created }}">{{ post.rel_time }}</span>
-		{% if !post.awards.is_empty() %}
+		{% match post.awards %}
+		{% when Some with (values) %}
 		<span class="dot">&bull;</span>
 		<span class="awards">
-			{% for award in post.awards.clone() %}
+			{% for award in values.clone().iter() %}
 			<span class="award" title="{{ award.name }}">
 				<img alt="{{ award.name }}" src="{{ award.icon_url }}" width="16" height="16"/>
 				{{ award.count }}
 			</span>
 			{% endfor %}
 		</span>
-		{% endif %}
+		{% when None %}
+		{% endmatch %}
 	</p>
 	<h1 class="post_title">
 		{{ post.title }}
@@ -178,13 +180,15 @@
 		<a class="post_author {{ post.author.distinguished }}" href="/u/{{ post.author.name }}">u/{{ post.author.name }}</a>
 		<span class="dot">&bull;</span>
 		<span class="created" title="{{ post.created }}">{{ post.rel_time }}</span>
-		{% if !post.awards.is_empty() %}
-			{% for award in post.awards.clone() %}
+		{% match post.awards %}
+		{% when Some with (values) %}
+			{% for award in values.clone().iter() %}
 			<span class="award" title="{{ award.name }}">
 				<img alt="{{ award.name }}" src="{{ award.icon_url }}" width="16" height="16"/>
 			</span>
 			{% endfor %}
-		{% endif %}
+		{% when None %}
+		{% endmatch %}
 	</p>
 	<h2 class="post_title">
 		{% if post.flair.flair_parts.len() > 0 %}


### PR DESCRIPTION
While this implementation is not very clean (code-wise), it does ensure that, the awards aren't even parsed if the option to display awards is disabled.

I am sure this implementation could be improved, currently, the biggest challenge is accessing the settings without a request.

My question is, wouldn't it be better to use a singleton pattern for the settings?

If we used a singleton pattern for the settings, we could have a way to access a same instance of the config anywhere in the code. We could update the singleton values, if and only if, the user made changes in the "settings" page. Per my understanding of the code, currently, this request to read the settings is done every time a post is parsed, I am sure we might be able to benefit from only requesting setting "parsing" when necessary.

Anyway, this fixes #442  👍🏼 

I am open for suggestions and ways to improve the code, as I don't think the implementation is clean enough, but it could benefit from the singleton pattern I mentioned above.