### PR TITLE
Make CLI args have higher precedence than env vars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 askama = { version = "0.11.1", default-features = false }
 async-recursion = "1.0.0"
 cached = "0.40.0"
-clap = { version = "4.0.24", default-features = false, features = ["std"] }
+clap = { version = "4.0.24", default-features = false, features = ["std", "env"] }
 regex = "1.7.0"
 serde = { version = "1.0.147", features = ["derive"] }
 cookie = "0.16.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod user;
 mod utils;
 
 // Import Crates
-use clap::{Arg, Command};
+use clap::{Arg, ArgAction, Command};
 
 use futures_lite::FutureExt;
 use hyper::{header::HeaderValue, Body, Request, Response};
@@ -129,8 +129,10 @@ async fn main() {
 				.short('p')
 				.long("port")
 				.value_name("PORT")
+				.env("PORT")
 				.help("Port to listen on")
 				.default_value("8080")
+				.action(ArgAction::Set)
 				.num_args(1),
 		)
 		.arg(
@@ -144,11 +146,11 @@ async fn main() {
 		)
 		.get_matches();
 
-	let address = matches.get_one("address").map(|m: &String| m.as_str()).unwrap_or("0.0.0.0");
-	let port = std::env::var("PORT").unwrap_or_else(|_| matches.get_one("port").map(|m: &String| m.as_str()).unwrap_or("8080").to_string());
+	let address = matches.get_one::<String>("address").unwrap();
+	let port = matches.get_one::<String>("port").unwrap();
 	let hsts = matches.get_one("hsts").map(|m: &String| m.as_str());
 
-	let listener = [address, ":", &port].concat();
+	let listener = [address, ":", port].concat();
 
 	println!("Starting Libreddit...");
 


### PR DESCRIPTION
This simplifies the logic to build the listener by using more clap
features instead of manually accessing the PORT environment variable.
This also removes unnecessary `unwrap_or` calls that set defaults that
are already set by clap.

******

I stumbled on this while looking through the source code, and it looked like this part could have been simplified. I'm much more familiar with clap 2 than 3 or 4, so a review is appreciated!