### PR TITLE
Remove unused dep "async-recursion"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,17 +76,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,7 +662,6 @@ name = "libreddit"
 version = "0.26.0"
 dependencies = [
  "askama",
- "async-recursion",
  "brotli",
  "cached",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 
 [dependencies]
 askama = { version = "0.11.1", default-features = false }
-async-recursion = "1.0.0"
 cached = "0.40.0"
 clap = { version = "4.0.24", default-features = false, features = ["std"] }
 regex = "1.7.0"


### PR DESCRIPTION
Found using cargo-udeps. Checked; should be safe.
