### PR TITLE
Implement instance info endpoint (JSON, YAML, TXT)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_html"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ef018b44d829e1b3364b4969059c098743595ec57a7eed176fbc9d909ac217"
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +669,7 @@ version = "0.27.0"
 dependencies = [
  "askama",
  "brotli",
+ "build_html",
  "cached",
  "clap",
  "cookie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,7 @@ dependencies = [
  "sealed_test",
  "serde",
  "serde_json",
+ "serde_yaml",
  "time",
  "tokio",
  "toml",
@@ -771,6 +772,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -1159,6 +1169,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b5b431e8907b50339b51223b97d102db8d987ced36f6e4d03621db9316c834"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1290,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -1434,6 +1459,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ brotli = { version = "3.3.4", features = ["std"] }
 toml = "0.5.9"
 once_cell = "1.16.0"
 serde_yaml = "0.9.16"
+build_html = "2.2.0"
 
 [dev-dependencies]
 lipsum = "0.8.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,14 @@ percent-encoding = "2.2.0"
 route-recognizer = "0.3.1"
 serde_json = "1.0.87"
 tokio = { version = "1.21.2", features = ["full"] }
-time = "0.3.17"
+time = { version = "0.3.17", features = ["local-offset"] }
 url = "2.3.1"
 rust-embed = { version = "6.4.2", features = ["include-exclude"] }
 libflate = "1.2.0"
 brotli = { version = "3.3.4", features = ["std"] }
 toml = "0.5.9"
 once_cell = "1.16.0"
+serde_yaml = "0.9.16"
 
 [dev-dependencies]
 lipsum = "0.8.2"

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ Assign a default value for each instance-specific setting by passing environment
 
 |Name|Possible values|Default value|Description|
 |-|-|-|-|
-| `SFW_ONLY` | `["on", "off"]` | `off` | Enables SFW-only mode for the instance, i.e. all NSFW content is filtered. |
+| `SFW_ONLY` | `["on", "off"]` | `off`   | Enables SFW-only mode for the instance, i.e. all NSFW content is filtered. |
+| `BANNER`   | String          | (empty) | Allows the server to set a banner to be displayed. Currently this is displayed on the instance info page. | 
 
 ## Default User Settings
 
@@ -207,6 +208,7 @@ Assign a default value for each user-modifiable setting by passing environment v
 | `USE_HLS`               | `["on", "off"]`                                                                                     | `off`         |
 | `HIDE_HLS_NOTIFICATION` | `["on", "off"]`                                                                                     | `off`         |
 | `AUTOPLAY_VIDEOS`       | `["on", "off"]`                                                                                     | `off`         |
+| `HIDE_AWARDS`           | `["on", "off"]`                                                                                     | `off`
 
 You can also configure Libreddit with a configuration file. An example `libreddit.toml` can be found below:
 

--- a/app.json
+++ b/app.json
@@ -43,6 +43,12 @@
     },
     "LIBREDDIT_SFW_ONLY": {
       "required": false
+    },
+    "LIBREDDIT_DEFAULT_HIDE_AWARDS": {
+      "required": false
+    }
+    "LIBREDDIT_BANNER": {
+      "required": false
     }
   }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+use std::process::Command;
+fn main() {
+	let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
+	let git_hash = String::from_utf8(output.stdout).unwrap();
+	println!("cargo:rustc-env=GIT_HASH={git_hash}");
+}

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,20 @@
-use std::process::Command;
+use std::{
+	os::unix::process::ExitStatusExt,
+	process::{Command, ExitStatus, Output},
+};
 fn main() {
-	let output = String::from_utf8(Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap().stdout).unwrap_or_default();
+	let output = String::from_utf8(
+		Command::new("git")
+			.args(["rev-parse", "HEAD"])
+			.output()
+			.unwrap_or(Output {
+				stdout: vec![],
+				stderr: vec![],
+				status: ExitStatus::from_raw(0),
+			})
+			.stdout,
+	)
+	.unwrap_or_default();
 	let git_hash = if output == String::default() { "dev".into() } else { output };
 	println!("cargo:rustc-env=GIT_HASH={git_hash}");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 use std::process::Command;
 fn main() {
-	let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
-	let git_hash = String::from_utf8(output.stdout).unwrap();
+	let output = String::from_utf8(Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap().stdout).unwrap_or_default();
+	let git_hash = if output == String::default() { "dev".into() } else { output };
 	println!("cargo:rustc-env=GIT_HASH={git_hash}");
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
 use std::{env::var, fs::read_to_string};
 
 // Waiting for https://github.com/rust-lang/rust/issues/74465 to land, so we
@@ -6,44 +7,47 @@ use std::{env::var, fs::read_to_string};
 //
 // This is the local static that is initialized at runtime (technically at
 // first request) and contains the instance settings.
-static CONFIG: Lazy<Config> = Lazy::new(Config::load);
+pub(crate) static CONFIG: Lazy<Config> = Lazy::new(Config::load);
 
 /// Stores the configuration parsed from the environment variables and the
 /// config file. `Config::Default()` contains None for each setting.
-#[derive(Default, serde::Deserialize)]
+/// When adding more config settings, add it to `Config::load`,
+/// `get_setting_from_config`, both below, as well as
+/// instance_info::InstanceInfo.to_string(), README.md and app.json.
+#[derive(Default, Serialize, Deserialize, Clone)]
 pub struct Config {
 	#[serde(rename = "LIBREDDIT_SFW_ONLY")]
-	sfw_only: Option<String>,
+	pub(crate) sfw_only: Option<String>,
 
 	#[serde(rename = "LIBREDDIT_DEFAULT_THEME")]
-	default_theme: Option<String>,
+	pub(crate) default_theme: Option<String>,
 
 	#[serde(rename = "LIBREDDIT_DEFAULT_FRONT_PAGE")]
-	default_front_page: Option<String>,
+	pub(crate) default_front_page: Option<String>,
 
 	#[serde(rename = "LIBREDDIT_DEFAULT_LAYOUT")]
-	default_layout: Option<String>,
+	pub(crate) default_layout: Option<String>,
 
 	#[serde(rename = "LIBREDDIT_DEFAULT_WIDE")]
-	default_wide: Option<String>,
+	pub(crate) default_wide: Option<String>,
 
 	#[serde(rename = "LIBREDDIT_DEFAULT_COMMENT_SORT")]
-	default_comment_sort: Option<String>,
+	pub(crate) default_comment_sort: Option<String>,
 
 	#[serde(rename = "LIBREDDIT_DEFAULT_POST_SORT")]
-	default_post_sort: Option<String>,
+	pub(crate) default_post_sort: Option<String>,
 
 	#[serde(rename = "LIBREDDIT_DEFAULT_SHOW_NSFW")]
-	default_show_nsfw: Option<String>,
+	pub(crate) default_show_nsfw: Option<String>,
 
 	#[serde(rename = "LIBREDDIT_DEFAULT_BLUR_NSFW")]
-	default_blur_nsfw: Option<String>,
+	pub(crate) default_blur_nsfw: Option<String>,
 
 	#[serde(rename = "LIBREDDIT_DEFAULT_USE_HLS")]
-	default_use_hls: Option<String>,
+	pub(crate) default_use_hls: Option<String>,
 
 	#[serde(rename = "LIBREDDIT_DEFAULT_HIDE_HLS_NOTIFICATION")]
-	default_hide_hls_notification: Option<String>,
+	pub(crate) default_hide_hls_notification: Option<String>,
 }
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,12 @@ pub struct Config {
 
 	#[serde(rename = "LIBREDDIT_DEFAULT_HIDE_HLS_NOTIFICATION")]
 	pub(crate) default_hide_hls_notification: Option<String>,
+
+	#[serde(rename = "LIBREDDIT_DEFAULT_HIDE_AWARDS")]
+	pub(crate) default_hide_awards: Option<String>,
+
+	#[serde(rename = "LIBREDDIT_BANNER")]
+	pub(crate) banner: Option<String>,
 }
 
 impl Config {
@@ -74,6 +80,8 @@ impl Config {
 			default_blur_nsfw: parse("LIBREDDIT_DEFAULT_BLUR_NSFW"),
 			default_use_hls: parse("LIBREDDIT_DEFAULT_USE_HLS"),
 			default_hide_hls_notification: parse("LIBREDDIT_DEFAULT_HIDE_HLS"),
+			default_hide_awards: parse("LIBREDDIT_DEFAULT_HIDE_AWARDS"),
+			banner: parse("LIBREDDIT_BANNER"),
 		}
 	}
 }
@@ -91,6 +99,8 @@ fn get_setting_from_config(name: &str, config: &Config) -> Option<String> {
 		"LIBREDDIT_DEFAULT_USE_HLS" => config.default_use_hls.clone(),
 		"LIBREDDIT_DEFAULT_HIDE_HLS_NOTIFICATION" => config.default_hide_hls_notification.clone(),
 		"LIBREDDIT_DEFAULT_WIDE" => config.default_wide.clone(),
+		"LIBREDDIT_DEFAULT_HIDE_AWARDS" => config.default_hide_awards.clone(),
+		"LIBREDDIT_BANNER" => config.banner.clone(),
 		_ => None,
 	}
 }

--- a/src/instance_info.rs
+++ b/src/instance_info.rs
@@ -1,0 +1,108 @@
+use hyper::{http::Error, Body, Request, Response};
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+use crate::{
+	config::{Config, CONFIG},
+	server::RequestExt,
+};
+
+// This is the local static that is intialized at runtime (technically at
+// the first request *to the instance-info endpoint) and contains the data
+// retrieved from the instance-info endpoint.
+pub(crate) static INSTANCE_INFO: Lazy<InstanceInfo> = Lazy::new(InstanceInfo::new);
+
+/// Handles instance info endpoint
+pub async fn instance_info(req: Request<Body>) -> Result<Response<Body>, String> {
+	let extension = req.param("extension").unwrap_or("json".into());
+	let response = match extension.as_str() {
+		"yaml" => info_yaml(),
+		"txt" => info_txt(),
+		"json" | _ => info_json(),
+	};
+	response.map_err(|err| format!("{err}"))
+}
+
+fn info_json() -> Result<Response<Body>, Error> {
+	let body = serde_json::to_string(&*INSTANCE_INFO).unwrap_or("Error serializing JSON.".into());
+	Response::builder().status(200).header("content-type", "application/json").body(body.into())
+}
+
+fn info_yaml() -> Result<Response<Body>, Error> {
+	let body = serde_yaml::to_string(&*INSTANCE_INFO).unwrap_or("Error serializing YAML.".into());
+	// https://github.com/ietf-wg-httpapi/mediatypes/blob/main/draft-ietf-httpapi-yaml-mediatypes.md
+	Response::builder().status(200).header("content-type", "application/yaml").body(body.into())
+}
+
+fn info_txt() -> Result<Response<Body>, Error> {
+	Response::builder()
+		.status(200)
+		.header("content-type", "text/plain")
+		.body((INSTANCE_INFO.to_string()).into())
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub(crate) struct InstanceInfo {
+	crate_version: String,
+	git_commit: String,
+	deploy_date: String,
+	compile_mode: String,
+	deploy_unix_ts: i64,
+	config: Config,
+}
+
+impl InstanceInfo {
+	pub fn new() -> Self {
+		Self {
+			crate_version: env!("CARGO_PKG_VERSION").to_string(),
+			git_commit: env!("GIT_HASH").to_string(),
+			deploy_date: OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc()).to_string(),
+			#[cfg(debug_assertions)]
+			compile_mode: "Debug".into(),
+			#[cfg(not(debug_assertions))]
+			compile_mode: "Release".into(),
+			deploy_unix_ts: OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc()).unix_timestamp(),
+			config: CONFIG.clone(),
+		}
+	}
+}
+impl ToString for InstanceInfo {
+	fn to_string(&self) -> String {
+		format!(
+			"Crate version: {}\n
+                Git commit: {}\n
+                Deploy date: {}\n
+                Deploy timestamp: {}\n
+                Compile mode: {}\n
+                Config:\n
+                    SFW only: {:?}\n
+                    Default theme: {:?}\n
+                    Default front page: {:?}\n
+                    Default layout: {:?}\n
+                    Default wide: {:?}\n
+                    Default comment sort: {:?}\n
+                    Default post sort: {:?}\n
+                    Default show NSFW: {:?}\n
+                    Default blur NSFW: {:?}\n
+                    Default use HLS: {:?}\n
+                    Default hide HLS notification: {:?}\n",
+			self.crate_version,
+			self.git_commit,
+			self.deploy_date,
+			self.deploy_unix_ts,
+			self.compile_mode,
+			self.config.sfw_only,
+			self.config.default_theme,
+			self.config.default_front_page,
+			self.config.default_layout,
+			self.config.default_wide,
+			self.config.default_comment_sort,
+			self.config.default_post_sort,
+			self.config.default_show_nsfw,
+			self.config.default_blur_nsfw,
+			self.config.default_use_hls,
+			self.config.default_hide_hls_notification
+		)
+	}
+}

--- a/src/instance_info.rs
+++ b/src/instance_info.rs
@@ -11,8 +11,8 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 // This is the local static that is intialized at runtime (technically at
-// the first request *to the instance-info endpoint) and contains the data
-// retrieved from the instance-info endpoint.
+// the first request to the info endpoint) and contains the data
+// retrieved from the info endpoint.
 pub(crate) static INSTANCE_INFO: Lazy<InstanceInfo> = Lazy::new(InstanceInfo::new);
 
 /// Handles instance info endpoint

--- a/src/instance_info.rs
+++ b/src/instance_info.rs
@@ -1,12 +1,14 @@
+use crate::{
+	config::{Config, CONFIG},
+	server::RequestExt,
+	utils::Preferences,
+};
+use askama::Template;
+use build_html::{Container, Html, HtmlContainer, Table};
 use hyper::{http::Error, Body, Request, Response};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
-
-use crate::{
-	config::{Config, CONFIG},
-	server::RequestExt,
-};
 
 // This is the local static that is intialized at runtime (technically at
 // the first request *to the instance-info endpoint) and contains the data
@@ -15,11 +17,14 @@ pub(crate) static INSTANCE_INFO: Lazy<InstanceInfo> = Lazy::new(InstanceInfo::ne
 
 /// Handles instance info endpoint
 pub async fn instance_info(req: Request<Body>) -> Result<Response<Body>, String> {
-	let extension = req.param("extension").unwrap_or("json".into());
+	// This will retrieve the extension given, or create a new string - which will
+	// simply become the last option, an HTML page.
+	let extension = req.param("extension").unwrap_or(String::new());
 	let response = match extension.as_str() {
 		"yaml" => info_yaml(),
 		"txt" => info_txt(),
-		"json" | _ => info_json(),
+		"json" => info_json(),
+		"html" | _ => info_html(req),
 	};
 	response.map_err(|err| format!("{err}"))
 }
@@ -39,9 +44,19 @@ fn info_txt() -> Result<Response<Body>, Error> {
 	Response::builder()
 		.status(200)
 		.header("content-type", "text/plain")
-		.body((INSTANCE_INFO.to_string()).into())
+		.body(INSTANCE_INFO.to_string(StringType::Raw).into())
 }
-
+fn info_html(req: Request<Body>) -> Result<Response<Body>, Error> {
+	let message = MessageTemplate {
+		title: String::from("Instance information"),
+		body: INSTANCE_INFO.to_string(StringType::Html),
+		prefs: Preferences::new(&req),
+		url: req.uri().to_string(),
+	}
+	.render()
+	.unwrap();
+	Response::builder().status(200).header("content-type", "text/html; charset=utf8").body(message.into())
+}
 #[derive(Serialize, Deserialize, Default)]
 pub(crate) struct InstanceInfo {
 	crate_version: String,
@@ -66,16 +81,47 @@ impl InstanceInfo {
 			config: CONFIG.clone(),
 		}
 	}
-}
-impl ToString for InstanceInfo {
-	fn to_string(&self) -> String {
-		format!(
-			"Crate version: {}\n
+	fn to_table(&self) -> String {
+		let mut container = Container::default();
+		let convert = |o: &Option<String>| -> String { o.clone().unwrap_or("Unset".to_owned()) };
+		container.add_header(3, "Instance banner");
+		container.add_raw("<br />");
+		container.add_paragraph(convert(&self.config.banner));
+		container.add_raw("<br />");
+		container.add_table(Table::from([
+			["Crate version", &self.crate_version],
+			["Git commit", &self.git_commit],
+			["Deploy date", &self.deploy_date],
+			["Deploy timestamp", &self.deploy_unix_ts.to_string()],
+			["Compile mode", &self.compile_mode],
+			["<b>Settings</b>", "<b>Settings</b>"],
+			["SFW only", &convert(&self.config.sfw_only)],
+			["Hide awards", &convert(&self.config.default_hide_awards)],
+			["Default theme", &convert(&self.config.default_theme)],
+			["Default front page", &convert(&self.config.default_front_page)],
+			["Default layout", &convert(&self.config.default_layout)],
+			["Default wide", &convert(&self.config.default_wide)],
+			["Default comment sort", &convert(&self.config.default_comment_sort)],
+			["Default post sort", &convert(&self.config.default_post_sort)],
+			["Default show NSFW", &convert(&self.config.default_show_nsfw)],
+			["Default blur NSFW", &convert(&self.config.default_blur_nsfw)],
+			["Default use HLS", &convert(&self.config.default_use_hls)],
+			["Default hide HLS notification", &convert(&self.config.default_hide_hls_notification)],
+		]));
+		container.to_html_string()
+	}
+	fn to_string(&self, string_type: StringType) -> String {
+		match string_type {
+			StringType::Raw => {
+				format!(
+					"Crate version: {}\n
                 Git commit: {}\n
                 Deploy date: {}\n
                 Deploy timestamp: {}\n
                 Compile mode: {}\n
                 Config:\n
+                    Banner: {:?}\n
+                    Hide awards: {:?}\n
                     SFW only: {:?}\n
                     Default theme: {:?}\n
                     Default front page: {:?}\n
@@ -87,22 +133,39 @@ impl ToString for InstanceInfo {
                     Default blur NSFW: {:?}\n
                     Default use HLS: {:?}\n
                     Default hide HLS notification: {:?}\n",
-			self.crate_version,
-			self.git_commit,
-			self.deploy_date,
-			self.deploy_unix_ts,
-			self.compile_mode,
-			self.config.sfw_only,
-			self.config.default_theme,
-			self.config.default_front_page,
-			self.config.default_layout,
-			self.config.default_wide,
-			self.config.default_comment_sort,
-			self.config.default_post_sort,
-			self.config.default_show_nsfw,
-			self.config.default_blur_nsfw,
-			self.config.default_use_hls,
-			self.config.default_hide_hls_notification
-		)
+					self.crate_version,
+					self.git_commit,
+					self.deploy_date,
+					self.deploy_unix_ts,
+					self.compile_mode,
+					self.config.banner,
+					self.config.default_hide_awards,
+					self.config.sfw_only,
+					self.config.default_theme,
+					self.config.default_front_page,
+					self.config.default_layout,
+					self.config.default_wide,
+					self.config.default_comment_sort,
+					self.config.default_post_sort,
+					self.config.default_show_nsfw,
+					self.config.default_blur_nsfw,
+					self.config.default_use_hls,
+					self.config.default_hide_hls_notification
+				)
+			}
+			StringType::Html => self.to_table(),
+		}
 	}
+}
+enum StringType {
+	Raw,
+	Html,
+}
+#[derive(Template)]
+#[template(path = "message.html")]
+struct MessageTemplate {
+	title: String,
+	body: String,
+	prefs: Preferences,
+	url: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 // Reference local files
 mod config;
 mod duplicates;
+mod instance_info;
 mod post;
 mod search;
 mod settings;
@@ -20,6 +21,7 @@ use hyper::{header::HeaderValue, Body, Request, Response};
 
 mod client;
 use client::{canonical_path, proxy};
+use once_cell::sync::Lazy;
 use server::RequestExt;
 use utils::{error, redirect, ThemeAssets};
 
@@ -156,6 +158,13 @@ async fn main() {
 	// Begin constructing a server
 	let mut app = server::Server::new();
 
+	// Force evaluation of statics. In instance_info case, we need to evaluate
+	// the timestamp so deploy date is accurate - in config case, we need to 
+	// evaluate the configuration to avoid paying penalty at first request.
+
+	Lazy::force(&config::CONFIG);
+	Lazy::force(&instance_info::INSTANCE_INFO);
+
 	// Define default headers (added to all responses)
 	app.default_headers = headers! {
 		"Referrer-Policy" => "no-referrer",
@@ -282,6 +291,10 @@ async fn main() {
 
 	// Handle about pages
 	app.at("/about").get(|req| error(req, "About pages aren't added yet".to_string()).boxed());
+
+	// Instance info page
+	app.at("/instance-info").get(|r| instance_info::instance_info(r).boxed());
+	app.at("/instance-info.:extension").get(|r| instance_info::instance_info(r).boxed());
 
 	app.at("/:id").get(|req: Request<Body>| {
 		Box::pin(async move {

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,8 +295,8 @@ async fn main() {
 	app.at("/about").get(|req| error(req, "About pages aren't added yet".to_string()).boxed());
 
 	// Instance info page
-	app.at("/instance-info").get(|r| instance_info::instance_info(r).boxed());
-	app.at("/instance-info.:extension").get(|r| instance_info::instance_info(r).boxed());
+	app.at("/info").get(|r| instance_info::instance_info(r).boxed());
+	app.at("/info.:extension").get(|r| instance_info::instance_info(r).boxed());
 
 	app.at("/:id").get(|req: Request<Body>| {
 		Box::pin(async move {

--- a/static/style.css
+++ b/static/style.css
@@ -173,13 +173,24 @@ body > footer {
 	margin: 20px;
 }
 
-body > footer > div#sfw-only {
-	color: var(--green);
-	border: 1px solid var(--green);
-	padding: 5px;
+.info-button {
+	align-items: center;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	border-radius: .25rem;
+	box-shadow: rgba(0, 0, 0, 0.02) 0 1px 3px 0;
 	box-sizing: border-box;
-	border-radius: 5px;
+	color: rgba(0, 0, 0, 0.85);
+	cursor: pointer;
+	display: inline-flex;
+	padding: 0.5em;
 }
+.info-button:hover,
+.info-button:focus {
+	border-color: rgba(0, 0, 0, 0.15);
+	box-shadow: rgba(0, 0, 0, 0.1) 0 4px 12px;
+	color: rgba(0, 0, 0, 0.65);
+}
+
 /* / Body footer. */
 
 /* Footer in content block. */
@@ -1226,6 +1237,10 @@ input[type="submit"] {
 	padding: 10px;
 	width: 250px;
 	background: var(--highlighted) !important;
+}
+/* Info page */
+.unset {
+	color: lightslategrey;
 }
 
 /* Markdown */

--- a/static/style.css
+++ b/static/style.css
@@ -169,7 +169,7 @@ main {
 /* Body footer. */
 body > footer {
 	display: flex;
-	justify-content: end;
+	justify-content: center;
 	margin: 20px;
 }
 
@@ -180,7 +180,13 @@ body > footer {
 	color: var(--text);
 	cursor: pointer;
 	display: inline-flex;
+	font-size: 300%;
+	font-weight: bold;
 	padding: 0.5em;
+}
+
+.info-button > a:hover {
+	text-decoration: none;
 }
 
 /* / Body footer. */

--- a/static/style.css
+++ b/static/style.css
@@ -169,26 +169,18 @@ main {
 /* Body footer. */
 body > footer {
 	display: flex;
-	justify-content: center;
+	justify-content: end;
 	margin: 20px;
 }
 
 .info-button {
 	align-items: center;
-	border: 1px solid rgba(0, 0, 0, 0.1);
 	border-radius: .25rem;
-	box-shadow: rgba(0, 0, 0, 0.02) 0 1px 3px 0;
 	box-sizing: border-box;
-	color: rgba(0, 0, 0, 0.85);
+	color: var(--text);
 	cursor: pointer;
 	display: inline-flex;
 	padding: 0.5em;
-}
-.info-button:hover,
-.info-button:focus {
-	border-color: rgba(0, 0, 0, 0.15);
-	box-shadow: rgba(0, 0, 0, 0.1) 0 4px 12px;
-	color: rgba(0, 0, 0, 0.65);
 }
 
 /* / Body footer. */

--- a/templates/base.html
+++ b/templates/base.html
@@ -68,7 +68,7 @@
 		{% block footer %}
 			<footer>
 				<div class="info-button">
-					<a href="/info">View instance information</a>
+					<a href="/info" title="View instance information">&#x24D8;</a>
 				</div>
 			</footer>
 		{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -66,6 +66,11 @@
 		</main>
 		{% endblock %}
 		{% block footer %}
+			<footer>
+				<div>
+					<a href="/instance-info">View instance information</a>
+				</div>
+			</footer>
 			{% if crate::utils::sfw_only() %}
 			<footer><div id="sfw-only">This instance of Libreddit is SFW-only.</div></footer>
 			{% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -67,13 +67,10 @@
 		{% endblock %}
 		{% block footer %}
 			<footer>
-				<div>
+				<div class="info-button">
 					<a href="/instance-info">View instance information</a>
 				</div>
 			</footer>
-			{% if crate::utils::sfw_only() %}
-			<footer><div id="sfw-only">This instance of Libreddit is SFW-only.</div></footer>
-			{% endif %}
 		{% endblock %}
 	</body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -68,7 +68,7 @@
 		{% block footer %}
 			<footer>
 				<div class="info-button">
-					<a href="/instance-info">View instance information</a>
+					<a href="/info">View instance information</a>
 				</div>
 			</footer>
 		{% endblock %}

--- a/templates/message.html
+++ b/templates/message.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}{{ title }}{% endblock %}
+{% block sortstyle %}{% endblock %}
+{% block content %}
+	<div id="message">
+		<h1>{{ title }}</h1>
+		<br>
+		{{ body|safe }}
+	</div>
+{% endblock %}


### PR DESCRIPTION
## https://685.fly.dev/

Fixes #624 

I added a feature to the `time` crate to allow for local timezone loading. I also added `serde_yaml` so we could return it in YAML form, as well as JSON and regular text; as well as `build_html` in order to more easily construct an HTML table. These are quite small dependencies. Here's what they look like: 

## HTML (default with /instance-info)
![image](https://user-images.githubusercontent.com/69441971/211889983-427fdad0-50ed-4aa1-96ff-62fe865b0837.png)

## JSON
![image](https://user-images.githubusercontent.com/69441971/210432981-4d703454-8682-47f1-abc8-043ec797532f.png)

## YAML 
![image](https://user-images.githubusercontent.com/69441971/210433039-dc4d7209-4465-4f15-8b0c-8c7cce7c9b44.png)

## TXT
![image](https://user-images.githubusercontent.com/69441971/210433118-e3646392-dba5-462a-8553-d99848312c9f.png)

The `build.rs` is required and standard practice to set a variable - AFAIK it's the easiest way to embed the latest commit hash. 

Within `instance_info.rs`, I made some choices - the `InstanceInfo` struct will be held in a Lazy. Currently nothing in the struct should change so it's okay to cache it. However, from #624: 

> * Maybe some kind of latency statistics? Average latency to reddit, average response latency, etc.
>  * Number of responses served

If we add either of these, it will change on the fly, so we need to revisit the use of a `Lazy<InstanceInfo>`.

Within the `instance_info` function, I choose `html` as the default.

In `main.rs`, I forced evaluation of the two relevant statics (config and instance info) to ensure deploy timestamp is accurate, and to avoid paying the penalty of parsing the config at the first request.

In conclusion, this PR will allow us to implement a system where we can easily check if an instance is actually online and lets us measure versions across the instance ecosystem. If we add metrics like average Reddit latency or number of responses served, we can more accurately predict the performance of certain servers and bias a redirect server (going to work on this in the coming days :wink:) towards those.

I also added a link to the instance info page into `base.html`: 
![image](https://user-images.githubusercontent.com/69441971/211890272-e2ff3615-9b26-49e4-a071-927adedd2873.png)

The groundwork is also laid for a banner #347  - it's been included in the parsing code and is shown on the instance page. We need to discuss whether we want to display it on regular pages (footer? header? where? etc) or just on the info page.

I also added a "LIBREDDIT_DEFAULT_HIDE_AWARDS" option for a default - in case a server operator wants to hide it by default (goes with #678).