### PR TITLE
Mark search query as safe in askama template

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -10,7 +10,7 @@
 {% block content %}
 	<div id="column_one">
 		<form id="search_sort">
-			<input id="search" type="text" name="q" placeholder="Search" value="{{ params.q }}" title="Search libreddit">
+			<input id="search" type="text" name="q" placeholder="Search" value="{{ params.q|safe }}" title="Search libreddit">
 			{% if sub != "" %}
 			<div id="inside">
 				<input type="checkbox" name="restrict_sr" id="restrict_sr" {% if params.restrict_sr != "" %}checked{% endif %}>


### PR DESCRIPTION
Fixes #677, now search queries are returned and displayed properly.

https://djc.github.io/askama/filters.html#safe

This is safe to unescape and mark as safe as it's a user query, not injected by any external sources (for example, a post)