### PR TITLE
config: fix SFW test

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -100,7 +100,7 @@ pub(crate) fn get_setting(name: &str) -> Option<String> {
 use {sealed_test::prelude::*, std::fs::write};
 
 #[test]
-#[sealed_test(env = [("LIBREDDIT_SFW_ONLY", "1")])]
+#[sealed_test(env = [("LIBREDDIT_SFW_ONLY", "on")])]
 fn test_env_var() {
 	assert!(crate::utils::sfw_only())
 }


### PR DESCRIPTION
I'm currently preparing the update for libreddit in [nixpkgs](https://github.com/NixOS/nixpkgs). 

But when running the tests, the newly added test "config::test_env_var" fails. When replacing the "1" value set for the test with "on"  the test succeeds. The README [says](https://github.com/libreddit/libreddit#instance-settings) that the expected values for "SFW_ONLY" are "on" and "off".

Before:

```
running 13 tests
test utils::tests::format_num_works ... ok
test server::tests::test_determine_compressor ... ok
test utils::tests::rewrite_urls_removes_backslashes ... ok
test utils::tests::test_format_url ... ok
test config::test_env_config_precedence ... ok
test config::test_config ... ok
test config::test_env_config_precedence ... ok
test config::test_alt_env_config_precedence ... ok
test config::test_env_var ... FAILED
test config::test_env_var ... FAILED
test config::test_config ... ok
test config::test_alt_env_config_precedence ... ok
test server::tests::test_compress_response ... ok

failures:

---- config::test_env_var stdout ----
thread 'config::test_env_var' panicked at 'child exited unsuccessfully with exit status: 70', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/rusty-forkfork-0.4.0/src/fork_test.rs:138:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

running 2 tests
thread 'main' panicked at 'assertion failed: crate::utils::sfw_only()', src/config.rs:105:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- config::test_env_var stdout ----
thread 'config::test_env_var' panicked at 'child exited unsuccessfully with exit status: 70', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/rusty-forkfork-0.4.0/src/fork_test.rs:138:9

running 2 tests
thread 'main' panicked at 'assertion failed: crate::utils::sfw_only()', src/config.rs:105:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    config::test_env_var
    config::test_env_var

test result: FAILED. 11 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.18s

error: test failed, to rerun pass `--bin libreddit`
```

After:

```
running 13 tests
test utils::tests::format_num_works ... ok
test server::tests::test_determine_compressor ... ok
test utils::tests::rewrite_urls_removes_backslashes ... ok
test utils::tests::test_format_url ... ok
test config::test_env_var ... ok
test config::test_env_config_precedence ... ok
test config::test_alt_env_config_precedence ... ok
test config::test_alt_env_config_precedence ... ok
test config::test_env_var ... ok
test config::test_config ... ok
test config::test_env_config_precedence ... ok
test config::test_config ... ok
test server::tests::test_compress_response ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.18s
```