### PR TITLE
Register `Dockerfile.*` as Dockerfiles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Dockerfile.* linguist-language=Dockerfile


### PR DESCRIPTION
This allows GitHub Linguist to generate slightly more accurate language
stats for this repository, and also enable syntax highlighting in the
GitHub web UI. Due to caching, it may take a few days for this change to
have a visible effect on github.com.

This should probably be considered a very low-priority PR :slightly_smiling_face:
