### PR TITLE
Make gated subreddits accessible by treating them as quarantined

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -140,7 +140,7 @@ fn request(method: &'static Method, path: String, redirect: bool, quarantine: bo
 		.header("Accept-Encoding", if method == Method::GET { "gzip" } else { "identity" })
 		.header("Accept-Language", "en-US,en;q=0.5")
 		.header("Connection", "keep-alive")
-		.header("Cookie", if quarantine { "_options=%7B%22pref_quarantine_optin%22%3A%20true%7D" } else { "" })
+		.header("Cookie", if quarantine { "_options=%7B%22pref_quarantine_optin%22%3A%20true%2C%20%22pref_gated_sr_optin%22%3A%20true%7D" } else { "" })
 		.body(Body::empty());
 
 	async move {

--- a/src/duplicates.rs
+++ b/src/duplicates.rs
@@ -212,7 +212,7 @@ pub async fn item(req: Request<Body>) -> Result<Response<Body>, String> {
 		Err(msg) => {
 			if msg == "quarantined" {
 				let sub = req.param("sub").unwrap_or_default();
-				quarantine(req, sub)
+				quarantine(req, sub, msg)
 			} else {
 				error(req, msg).await
 			}

--- a/src/duplicates.rs
+++ b/src/duplicates.rs
@@ -210,7 +210,7 @@ pub async fn item(req: Request<Body>) -> Result<Response<Body>, String> {
 
 		// Process error.
 		Err(msg) => {
-			if msg == "quarantined" {
+			if msg == "quarantined" || msg == "gated" {
 				let sub = req.param("sub").unwrap_or_default();
 				quarantine(req, sub, msg)
 			} else {

--- a/src/post.rs
+++ b/src/post.rs
@@ -78,7 +78,7 @@ pub async fn item(req: Request<Body>) -> Result<Response<Body>, String> {
 		}
 		// If the Reddit API returns an error, exit and send error page to user
 		Err(msg) => {
-			if msg == "quarantined" {
+			if msg == "quarantined" || msg == "gated" {
 				let sub = req.param("sub").unwrap_or_default();
 				quarantine(req, sub, msg)
 			} else {

--- a/src/post.rs
+++ b/src/post.rs
@@ -80,7 +80,7 @@ pub async fn item(req: Request<Body>) -> Result<Response<Body>, String> {
 		Err(msg) => {
 			if msg == "quarantined" {
 				let sub = req.param("sub").unwrap_or_default();
-				quarantine(req, sub)
+				quarantine(req, sub, msg)
 			} else {
 				error(req, msg).await
 			}

--- a/src/search.rs
+++ b/src/search.rs
@@ -147,7 +147,7 @@ pub async fn find(req: Request<Body>) -> Result<Response<Body>, String> {
 			Err(msg) => {
 				if msg == "quarantined" {
 					let sub = req.param("sub").unwrap_or_default();
-					quarantine(req, sub)
+					quarantine(req, sub, msg)
 				} else {
 					error(req, msg).await
 				}

--- a/src/search.rs
+++ b/src/search.rs
@@ -145,7 +145,7 @@ pub async fn find(req: Request<Body>) -> Result<Response<Body>, String> {
 				})
 			}
 			Err(msg) => {
-				if msg == "quarantined" {
+				if msg == "quarantined" || msg == "gated" {
 					let sub = req.param("sub").unwrap_or_default();
 					quarantine(req, sub, msg)
 				} else {

--- a/src/subreddit.rs
+++ b/src/subreddit.rs
@@ -144,7 +144,7 @@ pub async fn community(req: Request<Body>) -> Result<Response<Body>, String> {
 				})
 			}
 			Err(msg) => match msg.as_str() {
-				"quarantined" | "gated" => quarantine(req, sub_name),
+				"quarantined" | "gated" => quarantine(req, sub_name, msg),
 				"private" => error(req, format!("r/{} is a private community", sub_name)).await,
 				"banned" => error(req, format!("r/{} has been banned from Reddit", sub_name)).await,
 				_ => error(req, msg).await,
@@ -153,9 +153,9 @@ pub async fn community(req: Request<Body>) -> Result<Response<Body>, String> {
 	}
 }
 
-pub fn quarantine(req: Request<Body>, sub: String) -> Result<Response<Body>, String> {
+pub fn quarantine(req: Request<Body>, sub: String, restriction: String) -> Result<Response<Body>, String> {
 	let wall = WallTemplate {
-		title: format!("r/{} is quarantined", sub),
+		title: format!("r/{} is {}", sub, restriction),
 		msg: "Please click the button below to continue to this subreddit.".to_string(),
 		url: req.uri().to_string(),
 		sub,
@@ -324,7 +324,7 @@ pub async fn wiki(req: Request<Body>) -> Result<Response<Body>, String> {
 		}),
 		Err(msg) => {
 			if msg == "quarantined" {
-				quarantine(req, sub)
+				quarantine(req, sub, msg)
 			} else {
 				error(req, msg).await
 			}
@@ -362,7 +362,7 @@ pub async fn sidebar(req: Request<Body>) -> Result<Response<Body>, String> {
 		}),
 		Err(msg) => {
 			if msg == "quarantined" {
-				quarantine(req, sub)
+				quarantine(req, sub, msg)
 			} else {
 				error(req, msg).await
 			}

--- a/src/subreddit.rs
+++ b/src/subreddit.rs
@@ -323,7 +323,7 @@ pub async fn wiki(req: Request<Body>) -> Result<Response<Body>, String> {
 			url,
 		}),
 		Err(msg) => {
-			if msg == "quarantined" {
+			if msg == "quarantined" || msg == "gated" {
 				quarantine(req, sub, msg)
 			} else {
 				error(req, msg).await
@@ -361,7 +361,7 @@ pub async fn sidebar(req: Request<Body>) -> Result<Response<Body>, String> {
 			url,
 		}),
 		Err(msg) => {
-			if msg == "quarantined" {
+			if msg == "quarantined" || msg == "gated" {
 				quarantine(req, sub, msg)
 			} else {
 				error(req, msg).await

--- a/src/subreddit.rs
+++ b/src/subreddit.rs
@@ -144,7 +144,7 @@ pub async fn community(req: Request<Body>) -> Result<Response<Body>, String> {
 				})
 			}
 			Err(msg) => match msg.as_str() {
-				"quarantined" => quarantine(req, sub_name),
+				"quarantined" | "gated" => quarantine(req, sub_name),
 				"private" => error(req, format!("r/{} is a private community", sub_name)).await,
 				"banned" => error(req, format!("r/{} has been banned from Reddit", sub_name)).await,
 				_ => error(req, msg).await,


### PR DESCRIPTION
Addresses #697, this would be at least a temporary fix to make gated communities such as r/drugs accessible, as right now there's no way to get past the `gated` messages.