### PR TITLE
Move unimportant links to footer

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -99,6 +99,8 @@ body {
 	background: var(--background);
 	font-size: 15px;
 	padding-top: 60px;
+	min-height: calc(100vh - 60px);
+	position: relative;
 }
 
 nav {
@@ -264,6 +266,7 @@ main {
 	max-width: 1000px;
 	padding: 10px 20px;
 	margin: 0 auto;
+	padding-bottom: 4em;
 }
 
 .wide main {
@@ -288,9 +291,9 @@ body > footer {
 	justify-content: center;
 	align-items: center;
 	width: 100vw;
+	background: var(--post);
 	position: absolute;
 	bottom: 0;
-	background: var(--post);
 }
 
 .footer-button {

--- a/static/style.css
+++ b/static/style.css
@@ -142,12 +142,6 @@ nav #links svg {
 	display: none;
 }
 
-nav #version {
-	opacity: 50%;
-	vertical-align: -2px;
-	margin-right: 10px;
-}
-
 nav #libreddit {
 	vertical-align: -2px;
 }
@@ -292,22 +286,22 @@ main {
 body > footer {
 	display: flex;
 	justify-content: center;
-	margin: 20px;
+	align-items: center;
+	width: 100vw;
+	position: absolute;
+	bottom: 0;
+	background: var(--post);
 }
 
-.info-button {
+.footer-button {
 	align-items: center;
 	border-radius: .25rem;
 	box-sizing: border-box;
 	color: var(--text);
 	cursor: pointer;
 	display: inline-flex;
-	font-size: 150%;
-	padding: 0.5em;
-}
-
-.info-button > a:hover {
-	text-decoration: none;
+	padding-left: 1em;
+	opacity: 0.8;
 }
 
 /* / Body footer. */
@@ -1551,7 +1545,6 @@ td, th {
 
 @media screen and (max-width: 480px) {
 	body { padding-top: 100px; }
-	#version { display: none; }
 
 	.post {
 		grid-template: 	"post_header post_header post_thumbnail" auto

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,6 @@
 		<nav>
 			<div id="logo">
 				<a id="libreddit" href="/"><span id="lib">lib</span><span id="reddit">reddit.</span></a>
-				<span id="version">v{{ env!("CARGO_PKG_VERSION") }}</span>
 				{% block subscriptions %}{% endblock %}
 			</div>
 			{% block search %}{% endblock %}
@@ -54,13 +53,6 @@
 						<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
 					</svg>
 				</a>
-				<a id="code" href="https://github.com/libreddit/libreddit" target="_blank" rel="noopener noreferrer">
-					<span>code</span>
-					<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-						<title>code</title>
-						<polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>
-					</svg>
-				</a>
 			</div>
 		</nav>
 		
@@ -71,10 +63,16 @@
 			{% endblock %}
 		</main>
 		{% endblock %}
+
+		<!-- FOOTER -->
 		{% block footer %}
 			<footer>
-				<div class="info-button">
-					<a href="/info" title="View instance information">&#x24D8;</a>
+				<p id="version">v{{ env!("CARGO_PKG_VERSION") }}</p>
+				<div class="footer-button">
+					<a href="/info" title="View instance information">ⓘ View instance info</a>
+				</div>
+				<div class="footer-button">
+					<a href="https://github.com/libreddit/libreddit" title="View code on GitHub">&lt;&gt; Code</a>
 				</div>
 			</footer>
 		{% endblock %}


### PR DESCRIPTION
Moves version number and code link to a minimal footer at the bottom middle of each page. This allows version number to be seen on mobile. Also reduced prominence of instance info button to address https://github.com/libreddit/libreddit/issues/716