### PR TITLE
Display previews and inline images for reddit-hosted images.

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -163,6 +163,9 @@ impl Media {
 			gallery = GalleryMedia::parse(&data["gallery_data"]["items"], &data["media_metadata"]);
 
 			("gallery", &data["url"], None)
+		} else if data["is_reddit_media_domain"].as_bool().unwrap_or_default() && data["domain"] == "i.redd.it" {
+			// If this post contains a reddit media (image) URL.
+			("image", &data["url"], None)
 		} else {
 			// If type can't be determined, return url
 			("link", &data["url"], None)
@@ -177,6 +180,8 @@ impl Media {
 			Self {
 				url: format_url(url_val.as_str().unwrap_or_default()),
 				alt_url,
+				// Note: in the data["is_reddit_media_domain"] path above
+				// width and height will be 0.
 				width: source["width"].as_i64().unwrap_or_default(),
 				height: source["height"].as_i64().unwrap_or_default(),
 				poster: format_url(source["url"].as_str().unwrap_or_default()),

--- a/templates/utils.html
+++ b/templates/utils.html
@@ -100,6 +100,10 @@
 	{% if post.post_type == "image" %}
 	<div class="post_media_content">
 		<a href="{{ post.media.url }}" class="post_media_image" >
+			{% if post.media.height == 0 || post.media.width == 0 %}
+			<!-- i.redd.it images speical case -->
+			<img width="100%" height="100%" loading="lazy" alt="Post image" src="{{ post.media.url }}"/>
+			{% else %}
 			<svg
 				width="{{ post.media.width }}px"
 				height="{{ post.media.height }}px"
@@ -109,6 +113,7 @@
 						<img loading="lazy" alt="Post image" src="{{ post.media.url }}"/>
 					</desc>
 			</svg>
+			{% endif %}
 		</a>
 	</div>
 	{% else if post.post_type == "video" || post.post_type == "gif" %}
@@ -216,7 +221,11 @@
 	<!-- POST MEDIA/THUMBNAIL -->
 	{% if (prefs.layout.is_empty() || prefs.layout == "card") && post.post_type == "image" %}
 	<div class="post_media_content">
-		<a href="{{ post.media.url }}" class="post_media_image {% if post.media.height / post.media.width < 2 %}short{% endif %}" >
+		<a href="{{ post.media.url }}" class="post_media_image {% if post.media.height < post.media.width*2 %}short{% endif %}" >
+			{% if post.media.height == 0 || post.media.width == 0 %}
+			<!-- i.redd.it images speical case -->
+			<img width="100%" height="100%" loading="lazy" alt="Post image" src="{{ post.media.url }}"/>
+			{% else %}
 			<svg
 				{%if post.flags.nsfw && prefs.blur_nsfw=="on" %}class="post_nsfw_blur"{% endif %}
 				width="{{ post.media.width }}px"
@@ -227,6 +236,7 @@
 						<img loading="lazy" alt="Post image" src="{{ post.media.url }}"/>
 					</desc>
 			</svg>
+			{% endif %}
 		</a>
 	</div>
 	{% else if (prefs.layout.is_empty() || prefs.layout == "card") && post.post_type == "gif" %}


### PR DESCRIPTION
This version does not change the svg behaviour in the non-ireddit cases in an attempt to reduce breakage.

This is a rebased version of the >1 year old PR #390.

The main difference is that there is no modification to the html in the non-ireddit case to prevent breaking random things.
The outcome of this PR is still a highly improved user-experience with regard to subreddits that use ireddit content, while introducing minor amount of content-reflow in these cases. All subs/pages that do not make use of ireddit content will continue to be reflow-free (no change).

The underlying problem has not changed since a year ago: ireddit content does not advertise (via the json API) its dimentions, and therefore we can only know its size only we actually load the image.

Opening this PR to hopefully revive some discussion.