### PR TITLE
fix build error on windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,13 @@
 use std::{
-	os::unix::process::ExitStatusExt,
-	os::windows::process::ExitStatusExt,
 	process::{Command, ExitStatus, Output},
 };
+
+#[cfg(not(target_os = "windows"))]
+use std::os::unix::process::ExitStatusExt;
+
+#[cfg(target_os = "windows")]
+use std::os::windows::process::ExitStatusExt;
+
 fn main() {
 	let output = String::from_utf8(
 		Command::new("git")

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 use std::{
 	os::unix::process::ExitStatusExt,
+	os::windows::process::ExitStatusExt,
 	process::{Command, ExitStatus, Output},
 };
 fn main() {


### PR DESCRIPTION
i expected libreddit to not work on windows, but when i installed it using cargo i got a build error, i fixed it and recompiled libreddit, ran it and it works just fine.