### PR TITLE
harden docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,18 @@ services:
     container_name: "libreddit"
     ports:
       - 8080:8080
+    user: nobody
+    read_only: true
+    security_opt:
+      - no-new-privileges: true
+    cap_drop:
+      - ALL
+    networks:
+      - libreddit
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "--tries=1", "http://localhost:8080/settings"]
       interval: 5m
       timeout: 3s
+
+networks:
+  libreddit:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     user: nobody
     read_only: true
     security_opt:
-      - no-new-privileges: true
+      - no-new-privileges:true
     cap_drop:
       - ALL
     networks:


### PR DESCRIPTION
`user: nobody`: the least privileged account.
`read_only: true`: this container doesn't write anything to the filesystem, this removes a vector.
`security_opt`: disallows the container to grab more privileges.
`cap_drop`: this container doesn't need any capabilities, drop them.
`networks`: put `libreddit` into its own network so it cannot see other containers by default.