### PR TITLE
fix(style): fit footer width to body size

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -293,7 +293,7 @@ body > footer {
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	width: 100vw;
+	width: 100%;
 	background: var(--post);
 	position: absolute;
 	bottom: 0;


### PR DESCRIPTION
Closes #750.

This patch makes the footer's width 100% of the body's width to ensure that it doesn't stick out. This gets rid of the horizontal scroll bar.