### PR TITLE
Add MUSL builds to GH Actions

### DIFF
--- a/.github/workflows/main-rust.yml
+++ b/.github/workflows/main-rust.yml
@@ -31,44 +31,51 @@ jobs:
         with:
           toolchain: stable
 
+      # Building actions
       - name: Build
         run: cargo build --release
 
-      - name: Build MUSL
-        run: cargo build --release --target x86_64-unknown-linux-musl
-
-      - name: Publish to crates.io
-        if: github.event_name == 'release'
-        run: cargo publish --no-verify --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      
-      - uses: actions/upload-artifact@v3
-        name: Upload a Build Artifact
-        with:
-          name: libreddit
-          path: target/release/libreddit
-        
-      - name: Versions
-        id: version
-        run: echo "VERSION=$(cargo metadata --format-version 1 --no-deps | jq .packages[0].version -r | sed 's/^/v/')" >> "$GITHUB_OUTPUT"
-          
       - name: Calculate SHA512 checksum
         run: sha512sum target/release/libreddit > libreddit.sha512
 
       - name: Calculate SHA256 checksum
         run: sha256sum target/release/libreddit > libreddit.sha256
-        
+
+      - name: Build MUSL
+        run: cargo build --release --target x86_64-unknown-linux-musl
+
       - name: Calculate MUSL SHA512 checksum
         run: sha512sum target/x86_64-unknown-linux-musl/release/libreddit > libreddit-musl.sha512
 
       - name: Calculate MUSL SHA256 checksum
         run: sha256sum target/x86_64-unknown-linux-musl/release/libreddit > libreddit-musl.sha256
-        
+
       - name: Move MUSL binary
         run: mv target/x86_64-unknown-linux-musl/release/libreddit target/x86_64-unknown-linux-musl/release/libreddit-musl
       
+      - uses: actions/upload-artifact@v3
+        name: Upload a Build Artifact
+        with:
+          name: libreddit
+          path: |
+          target/release/libreddit
+          target/x86_64-unknown-linux-musl/release/libreddit-musl
+          *.sha512
+          *.sha256
+        
+      - name: Versions
+        id: version
+        run: echo "VERSION=$(cargo metadata --format-version 1 --no-deps | jq .packages[0].version -r | sed 's/^/v/')" >> "$GITHUB_OUTPUT"
+        
+      # Publishing actions
+
+      - name: Publish to crates.io
+        if: github.event_name == 'release'
+        run: cargo publish --no-verify --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: github.base_ref != 'master'
+        if: github.base_ref != 'master' && github.event_name == 'release'
         with:
           tag_name: ${{ steps.version.outputs.VERSION }}
           name: ${{ steps.version.outputs.VERSION }} - ${{ github.event.head_commit.message }}

--- a/.github/workflows/main-rust.yml
+++ b/.github/workflows/main-rust.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build
         run: cargo build --release
 
+      - name: Build MUSL
+        run: cargo build --release --target x86_64-unknown-linux-musl
+
       - name: Publish to crates.io
         if: github.event_name == 'release'
         run: cargo publish --no-verify --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -54,6 +57,15 @@ jobs:
       - name: Calculate SHA256 checksum
         run: sha256sum target/release/libreddit > libreddit.sha256
         
+      - name: Calculate MUSL SHA512 checksum
+        run: sha512sum target/x86_64-unknown-linux-musl/release/libreddit > libreddit-musl.sha512
+
+      - name: Calculate MUSL SHA256 checksum
+        run: sha256sum target/x86_64-unknown-linux-musl/release/libreddit > libreddit-musl.sha256
+        
+      - name: Move MUSL binary
+        run: mv target/x86_64-unknown-linux-musl/release/libreddit target/x86_64-unknown-linux-musl/release/libreddit-musl
+      
       - name: Release
         uses: softprops/action-gh-release@v1
         if: github.base_ref != 'master'
@@ -65,6 +77,9 @@ jobs:
             target/release/libreddit
             libreddit.sha512
             libreddit.sha256
+            target/x86_64-unknown-linux-musl/release/libreddit-musl
+            libreddit-musl.sha512
+            libreddit-musl.sha256
           body: |
             - ${{ github.event.head_commit.message }} ${{ github.sha }}
           generate_release_notes: true


### PR DESCRIPTION
Fixes #809. Adds statically built MUSL binary which shouldn't have the same `libc` issues with Replit. This will also improve portability.