### PR TITLE
Initial PoC of spoofing Android OAuth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +723,7 @@ name = "libreddit"
 version = "0.30.1"
 dependencies = [
  "askama",
+ "base64",
  "brotli",
  "build_html",
  "cached",
@@ -735,6 +747,7 @@ dependencies = [
  "tokio",
  "toml",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1588,6 +1601,15 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ toml = "0.7.4"
 once_cell = "1.17.0"
 serde_yaml = "0.9.16"
 build_html = "2.2.0"
+uuid = { version = "1.3.3", features = ["v4"] }
+base64 = "0.21.2"
 
 [dev-dependencies]
 lipsum = "0.9.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 mod config;
 mod duplicates;
 mod instance_info;
+mod oauth;
 mod post;
 mod search;
 mod settings;
@@ -24,6 +25,8 @@ use client::{canonical_path, proxy};
 use once_cell::sync::Lazy;
 use server::RequestExt;
 use utils::{error, redirect, ThemeAssets};
+
+use crate::client::OAUTH_CLIENT;
 
 mod server;
 
@@ -166,6 +169,11 @@ async fn main() {
 
 	Lazy::force(&config::CONFIG);
 	Lazy::force(&instance_info::INSTANCE_INFO);
+
+	// Force login of Oauth client
+	#[allow(clippy::await_holding_lock)] 
+	// We don't care if we are awaiting a lock here - it's just locked once at init.
+	OAUTH_CLIENT.write().unwrap().login().await;
 
 	// Define default headers (added to all responses)
 	app.default_headers = headers! {

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1,0 +1,53 @@
+use std::collections::HashMap;
+
+use crate::client::CLIENT;
+use base64::{engine::general_purpose, Engine as _};
+use hyper::{client, Body, Method, Request};
+use serde_json::json;
+
+static REDDIT_ANDROID_OAUTH_CLIENT_ID: &str = "ohXpoqrZYub1kg";
+
+static AUTH_ENDPOINT: &str = "https://accounts.reddit.com";
+pub(crate) static USER_AGENT: &str = "Reddit/Version 2023.21.0/Build 956283/Android 13";
+
+pub(crate) struct Oauth {
+	// Currently unused, may be necessary if we decide to support GQL in the future
+	pub(crate) headers_map: HashMap<String, String>,
+	pub(crate) token: String,
+}
+
+impl Oauth {
+	pub fn new() -> Self {
+		let uuid = uuid::Uuid::new_v4().to_string();
+		Oauth {
+			headers_map: HashMap::from([
+				("Client-Vendor-Id".into(), uuid.clone()),
+				("X-Reddit-Device-Id".into(), uuid),
+				("User-Agent".into(), USER_AGENT.to_string()),
+			]),
+			token: String::new(),
+		}
+	}
+	pub async fn login(&mut self) -> Option<()> {
+		let url = format!("{}/api/access_token", AUTH_ENDPOINT);
+		let mut builder = Request::builder().method(Method::POST).uri(&url);
+		for (key, value) in self.headers_map.iter() {
+			builder = builder.header(key, value);
+		}
+
+		let auth = general_purpose::STANDARD.encode(format!("{REDDIT_ANDROID_OAUTH_CLIENT_ID}:"));
+		builder = builder.header("Authorization", format!("Basic {auth}"));
+		let json = json!({
+				"scopes": ["*","email","pii"]
+		});
+		let body = Body::from(json.to_string());
+		let request = builder.body(body).unwrap();
+		let client: client::Client<_, hyper::Body> = CLIENT.clone();
+		let resp = client.request(request).await.ok()?;
+		let body_bytes = hyper::body::to_bytes(resp.into_body()).await.ok()?;
+		let json: serde_json::Value = serde_json::from_slice(&body_bytes).ok()?;
+		self.token = json.get("access_token")?.as_str()?.to_string();
+		self.headers_map.insert("Authorization".to_owned(), format!("Bearer {}", self.token));
+		Some(())
+	}
+}


### PR DESCRIPTION
This is a proof of concept of using the Android OAuth endpoints to create an anonymous "android user" that then authorizes all requests. Couple of caveates:
* Does not use GraphQL endpoints at all.
  * GQL is faster and less rate-limited
  * GQL is likely going to be more stable or at least harder to block - android client doesn't necessarily use the OAuth endpoints I've used here so it's theoretically possible for them to block
  * GQL would likely require at least a whole new library dedicated to GraphQL API, whereas this was as easy as auth setup + replacing www.reddit.com with oauth.reddit.com
* DOES identify itself as an Android device, in headers. 
	* DOES NOT need the HMAC secret key that was reverse engineered out of the APK - no user accounts are logging in
* DOES NOT handle re-authenticating. Looks like the token expires after 24 hours. I'd like to figure out the proper way to refresh a token so the behavior more closely matches. Not sure exactly how to do that right now. Technically, since I'm just using OAuth endpoints, I could refresh them the normal way, but perhaps there's something special the real client does? (I worry that I must match the behavior exactly or else this will just be a cat and mouse game)
* Technically, does not actually pretend to be an android client to the letter - it just asks to log in as one then authenticates into the regular OAuth endpoints. This is definitely not standard behavior - for that I'd need to implement GQL. I doubt they're doing intense checking of this though.

Related to #785 #818.

HUGE thanks to @hogseedy and [@/costco on Hacker News](https://news.ycombinator.com/item?id=36086240) for the sample code. I'm just dipping my toes in with the OAuth endpoints, haven't yet touched the GQL ones.

TODO:

[ ] Token refreshing