### PR TITLE
Add ability to hide subreddit panel (closes #801)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -380,13 +380,17 @@ aside {
 	border-radius: 5px;
 	overflow: hidden;
 }
+#subreddit, #sidebar { min-width: 350px; }
 
 #user *, #subreddit * { text-align: center; }
 
 #user, #sub_meta, #sidebar_contents { padding: 20px; }
 
 #sidebar, #sidebar_contents { margin-top: 10px; }
-#sidebar_label { padding: 10px; }
+#sidebar_label, #subreddit_label {
+	padding: 10px;
+	text-align: left;
+}
 
 #user_icon, #sub_icon {
 	width: 100px;

--- a/templates/subreddit.html
+++ b/templates/subreddit.html
@@ -88,7 +88,8 @@
 				<center>(Content from r/{{ sub.name }} has been filtered)</center>
 			{% endif %}
 			{% if !sub.name.is_empty() && sub.name != "all" && sub.name != "popular" && !sub.name.contains("+") %}
-			<div class="panel" id="subreddit">
+			<details class="panel" id="subreddit" open>
+				<summary id="subreddit_label">Subreddit</summary>
 				{% if sub.wiki %}
 				<div id="top">
 					<div>Posts</div>
@@ -131,7 +132,7 @@
 						</div>
 					</div>
 				</div>
-			</div>
+			</details>
 			<details class="panel" id="sidebar">
 				<summary id="sidebar_label">Sidebar</summary>
 				<div id="sidebar_contents">


### PR DESCRIPTION
wraps the subreddit panel in a `<details>` to be able to hide it like the sidebar panel.

setting the min-width to `350px` is not ideal and does not look very good on screens with a width less than `370px`, but it is the only solution i could come up with to stop the width from changing when opening/closing the panels. if you have a better solution please suggest it.

closes #801.